### PR TITLE
fix(tirx): ConvertSSA — pop scoped buffer remaps by any dependent var (B00015/B00016)

### DIFF
--- a/src/tirx/transform/ir_utils.cc
+++ b/src/tirx/transform/ir_utils.cc
@@ -29,6 +29,7 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/ir/scope_stack.h>
 #include <tvm/s_tir/stmt.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/layout.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
@@ -84,6 +85,43 @@ Stmt MergeNest(const std::vector<std::vector<Stmt>>& nest, Stmt body) {
     body = MergeNest(*ri, body);
   }
   return body;
+}
+
+// A remapped buffer pushed onto IRConvertSSA::buf_remap_ may have been created
+// because *any* of the variables GetRemappedBuffer rewrites was SSA-renamed:
+// the data var, elem_offset, shape, strides, or the tile-layout shard/replica
+// iter extents/strides.  The scoped cleanup therefore has to recognise such a
+// buffer whenever *any* of those variables leaves scope -- not only when the
+// buffer's `data` var matches the popped rename.  The old data-var-only test
+// leaked buffers whose rename lived solely in `elem_offset` (a decl_buffer
+// created inside an unrolled DSMEM/TMA copy loop, whose data is the unchanged
+// shared pool pointer while elem_offset holds the loop var).  The stale buffer
+// was then reused by the next unrolled copy, injecting an out-of-scope loop var
+// into its elem_offset -> "used before definition" in split_host_device
+// (B00015 / B00016).
+static bool BufferDependsOnVar(const Buffer& buf, const VarNode* v) {
+  if (buf->data.get() == v) return true;
+  auto uses = [&](const PrimExpr& e) {
+    return e.defined() && UsesVar(e, [&](const VarNode* x) { return x == v; });
+  };
+  if (uses(buf->elem_offset)) return true;
+  for (const auto& e : buf->shape) {
+    if (uses(e)) return true;
+  }
+  for (const auto& e : buf->strides) {
+    if (uses(e)) return true;
+  }
+  if (buf->layout.defined()) {
+    if (auto opt_tile = buf->layout.value().as<TileLayoutNode>()) {
+      for (const auto& it : opt_tile->shard) {
+        if (uses(it->extent) || uses(it->stride)) return true;
+      }
+      for (const auto& it : opt_tile->replica) {
+        if (uses(it->extent) || uses(it->stride)) return true;
+      }
+    }
+  }
+  return false;
 }
 
 class IRConvertSSA final : public StmtExprMutator {
@@ -562,7 +600,7 @@ class IRConvertSSA final : public StmtExprMutator {
     var_remap_[old_var.get()].pop_back();
     for (auto& kv : buf_remap_) {
       std::vector<Buffer>& buffers = kv.second;
-      if (buffers.size() && (buffers.back()->data.get() == new_var.get())) {
+      if (buffers.size() && BufferDependsOnVar(buffers.back(), new_var.get())) {
         buffers.pop_back();
       }
     }
@@ -581,7 +619,7 @@ class IRConvertSSA final : public StmtExprMutator {
       var_remap_[remap.old_var.get()].pop_back();
       for (auto& kv : buf_remap_) {
         std::vector<Buffer>& buffers = kv.second;
-        if (buffers.size() && (buffers.back()->data.get() == remap.new_var.get())) {
+        if (buffers.size() && BufferDependsOnVar(buffers.back(), remap.new_var.get())) {
           buffers.pop_back();
         }
       }
@@ -618,7 +656,7 @@ class IRConvertSSA final : public StmtExprMutator {
         parent->var_remap_[remap.old_var.get()].pop_back();
         for (auto& kv : parent->buf_remap_) {
           std::vector<Buffer>& buffers = kv.second;
-          if (buffers.size() && (buffers.back()->data.get() == remap.new_var.get())) {
+          if (buffers.size() && BufferDependsOnVar(buffers.back(), remap.new_var.get())) {
             buffers.pop_back();
           }
         }
@@ -642,7 +680,7 @@ class IRConvertSSA final : public StmtExprMutator {
             parent->var_remap_[remap.old_var.get()].pop_back();
             for (auto& kv : parent->buf_remap_) {
               std::vector<Buffer>& buffers = kv.second;
-              if (buffers.size() && (buffers.back()->data.get() == remap.new_var.get())) {
+              if (buffers.size() && BufferDependsOnVar(buffers.back(), remap.new_var.get())) {
                 buffers.pop_back();
               }
             }

--- a/tests/python/tirx-transform/test_tir_transform_convert_ssa.py
+++ b/tests/python/tirx-transform/test_tir_transform_convert_ssa.py
@@ -535,5 +535,48 @@ def test_shared_shape_var_in_buffer_map_and_alloc_buffer():
     tvm.ir.assert_structural_equal(after["main"], before)
 
 
+def test_reused_loop_var_with_elem_offset_buffer():
+    """Regression (B00015 / B00016): a duplicated loop that DECLARES a buffer
+    whose SSA-relevant var lives in ``elem_offset`` (not ``data``).
+
+    This is the shape produced when a DSMEM / TMA ``copy_async`` — which emits
+    ``for loop_vars: decl_buffer(data=<shared pool ptr>, elem_offset=loop_vars*S)``
+    — is expanded inside ``for hc in T.unroll(N)``.  ``UnrollLoop`` duplicates the
+    body via ``Substitute`` (structurally sharing the ``loop_vars`` Var and the
+    Buffer object across copies) and then runs ``ConvertSSA`` to re-legalize.
+
+    ConvertSSA must give each copy a fresh loop var AND rebuild its
+    ``decl_buffer``'s ``elem_offset`` consistently.  The old scoped ``buf_remap_``
+    cleanup keyed only on the buffer's ``data`` var (unchanged here), so it leaked
+    the remapped buffer of an earlier copy; from the 3rd copy on that stale buffer
+    was reused, injecting a previous copy's out-of-scope loop var into
+    ``elem_offset`` -> ``variable loop_vars has been used before definition`` in
+    ``SplitHostDevice``.  Three sibling copies are the minimum to trip it.
+    """
+    # Manually construct the (intentionally non-SSA) body: three sibling For
+    # loops that all reuse the same loop_var Var and the same Buffer object,
+    # exactly as loop unrolling produces.
+    loop_var = tirx.Var("loop_vars", "int32")
+    buf = tirx.decl_buffer(
+        (128,), "float32", "buf", elem_offset=loop_var * 128, scope="shared.dyn"
+    )
+    one_for = tirx.For(
+        loop_var,
+        0,
+        128,
+        tirx.ForKind.SERIAL,
+        tirx.DeclBuffer(buf, tirx.Evaluate(tirx.BufferLoad(buf, [0]))),
+    )
+    body = tirx.SeqStmt([one_for, one_for, one_for])
+    before = tirx.PrimFunc([buf.data], body)
+
+    mod = tvm.IRModule.from_expr(before)
+    after = tvm.tirx.transform.ConvertSSA()(mod)
+
+    # After SSA conversion every loop var must be defined by its own For before
+    # use; verify_well_formed rejects the leaked out-of-scope var otherwise.
+    tvm.tirx.analysis.verify_well_formed(after["main"], assert_mode=True)
+
+
 if __name__ == "__main__":
     tvm.testing.main()


### PR DESCRIPTION
## Summary

Fixes **B00015 / B00016** — `variable loop_vars has been used before definition!`
raised in `split_host_device` (`var_use_def_analysis.cc:154`) when a DSMEM/TMA
`copy_async` is expanded inside `for hc in T.unroll(N)` with N ≥ 3 (the gdn_prefill
cluster-pair `H_mid` publish loop; v26_1 and v28_2).

## Root cause

`IRConvertSSA` (`src/tirx/transform/ir_utils.cc`), invoked by `UnrollLoop`, kept a
scoped `buf_remap_` stack and popped a remapped buffer on scope exit only when
`buffers.back()->data.get() == remap.new_var.get()` — i.e. it assumed the buffer's
`data` pointer was the SSA-renamed variable.

That invariant breaks for a `decl_buffer` whose renamed variable lives in
`elem_offset` (not `data`) — exactly what a DSMEM/TMA `copy_async` emits inside its
iteration loop: `for loop_vars: decl_buffer(data=<shared pool ptr>, elem_offset=loop_vars*S)`.
When such a copy is unrolled, `UnrollLoop` duplicates the body (structurally sharing
the loop var and the `Buffer` object); for the 2nd+ copy `ConvertSSA` renames the
loop var and pushes a new buffer to `buf_remap_`, but the `data`-var-keyed cleanup
never pops it. From the 3rd copy on, `GetRemappedBuffer` reuses that stale buffer,
injecting the previous copy's out-of-scope loop var into `elem_offset` → use-before-def.
(This is why `T.unroll(2)` was fine but `T.unroll(4)` crashed.)

## Fix

Replace the four `data`-only cleanup checks with a `BufferDependsOnVar(buf, v)`
helper that returns true if `v` appears in the buffer's `data`, `elem_offset`,
`shape`, `strides`, or tile-layout shard/replica iters — i.e. any field
`GetRemappedBuffer` rewrites. Strict superset of the old check; safe because a
freshly minted rename var can only occur in buffers created within its own scope
(top of their stacks). Adds `#include <tvm/tirx/analysis.h>` for `UsesVar`.

## Test

`tests/python/tirx-transform/test_tir_transform_convert_ssa.py::test_reused_loop_var_with_elem_offset_buffer`
— three sibling `For` loops sharing one loop var + a `decl_buffer` with the loop var
in `elem_offset`; asserts `verify_well_formed` after `ConvertSSA`. Fails before the
fix, passes after.

## Validation (rebuilt lib)

- `tests/python/tirx-transform/` — 316 passed, 8 xfailed
- `test_tir_transform_convert_ssa.py` — 14 passed (incl. new)
- `test_tir_transform_unroll_loop.py` — 4 passed
- DSMEM GPU e2e (`test_dsmem.py`) — 6 passed
- Kernels fp16_bf16_gemm / nvfp4_gemm / flash_attention4 — pass end-to-end on B200
- `tools/cpusim` full suite (tirx-kernels) — 1040 passed, 457 skipped, 0 failed
- All B00015/B00016 reproducers now compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
